### PR TITLE
fix: loosen docstring requirements

### DIFF
--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -111,7 +111,7 @@ skip_install = true
 deps =
     docstr-coverage
 commands =
-    docstr-coverage src/ tests/ --skip-private --skip-magic
+    docstr-coverage src/ tests/ --skip-private --skip-magic  --skip-file-doc --fail-under=90
 description = Run the docstr-coverage tool to check documentation coverage
 
 [testenv:docs]


### PR DESCRIPTION
The docstring requirements are to strict. Changes are:
--fail-under=90: only failing under 90% coverage instead of 100
--skip-file-doc: not requiring module dosctring because let's be real here